### PR TITLE
Trigger first render when joining program

### DIFF
--- a/lib/whistle/socket_handler.ex
+++ b/lib/whistle/socket_handler.ex
@@ -108,6 +108,8 @@ defmodule Whistle.SocketHandler do
                 program_connection
             end
 
+          send(self(), {:updated, program_name})
+
           {:reply, {:text, response},
            %{
              state


### PR DESCRIPTION
When joining a program, an initial diff wouldn't be triggered. Causing event handlers to not be attached.