### PR TITLE
Refactor Cowboy socket handler

### DIFF
--- a/lib/whistle/html.ex
+++ b/lib/whistle/html.ex
@@ -42,6 +42,15 @@ defmodule Whistle.Html do
   for tag <- @tags do
     tag_name = Atom.to_string(tag)
 
+    @doc """
+    Helper to create a `<#{tag_name}>` node.
+
+    ```
+    iex> Html.#{tag_name}([], "text")
+    {"#{tag_name}", {[], [{0, "text"}]}}
+    ```
+
+    """
     defmacro unquote(tag)(attributes \\ [], children \\ []) do
       build_quoted_node(unquote(tag_name), attributes, children)
     end
@@ -51,6 +60,15 @@ defmodule Whistle.Html do
     build_quoted_node(tag, attributes, children)
   end
 
+  @doc """
+  Create a link that will be handled by Whistle.
+
+  ```
+  iex> Html.ahref("/chat/general", [], "go to the homepage")
+  Html.a([href: "/chat/general", "data-whistle-href": true], "go to the homepage")
+  ```
+
+  """
   defmacro ahref(route, attributes, children) do
     attributes =
       quote do

--- a/lib/whistle/program/connection.ex
+++ b/lib/whistle/program/connection.ex
@@ -87,7 +87,7 @@ defmodule Whistle.Program.Connection do
     end
   end
 
-  def handle(conn, {handler, args}) do
+  def handle_event(conn, {handler, args}) do
     with {:ok, message} <- handler_message(conn, handler, args) do
       update(conn, message)
     end
@@ -98,8 +98,7 @@ defmodule Whistle.Program.Connection do
       {:ok, new_session, reply} = Instance.update(router, name, message, session)
       {:ok, %{conn | session: new_session}, reply}
     catch
-      :exit, value ->
-        IO.inspect value
+      :exit, _value ->
         {:error, :program_crash}
     end
   end

--- a/lib/whistle/program/connection.ex
+++ b/lib/whistle/program/connection.ex
@@ -87,19 +87,24 @@ defmodule Whistle.Program.Connection do
     end
   end
 
-  def update(program = %{router: router, name: name, session: session}, {handler, args}) do
-    with {:ok, message} <- handler_message(program, handler, args) do
-      try do
-        {:ok, new_session, reply} = Instance.update(router, name, message, session)
-        {:ok, %{program | session: new_session}, reply}
-      catch
-        :exit, _value ->
-          {:error, :program_crash}
-      end
+  def handle(conn = %{name: name, session: session}, {handler, args}) do
+    with {:ok, message} <- handler_message(conn, handler, args) do
+      update(conn, message)
     end
   end
 
-  def put_new_vdom(program = %{handlers: handlers, lazy_trees: trees, vdom: vdom}, new_vdom) do
+  def update(conn = %{router: router, name: name, session: session}, message) do
+    try do
+      {:ok, new_session, reply} = Instance.update(router, name, message, session)
+      {:ok, %{program | session: new_session}, reply}
+    catch
+      :exit, _value ->
+        {:error, :program_crash}
+    end
+  end
+
+  def update_view(program = %{handlers: handlers, lazy_trees: trees, vdom: vdom}) do
+    new_vdom = Instance.view(router, name, session)
     diff = Whistle.Html.Dom.diff(trees, vdom, new_vdom)
 
     handlers =

--- a/lib/whistle/socket_handler.ex
+++ b/lib/whistle/socket_handler.ex
@@ -151,7 +151,7 @@ defmodule Whistle.SocketHandler do
       {:ok, payload = %{"type" => type}} ->
         handle_event(type, state, payload)
 
-      {:error, err} ->
+      {:error, _} ->
         # TODO: log malformed JSON error
         {:ok, state}
     end

--- a/lib/whistle/socket_handler.ex
+++ b/lib/whistle/socket_handler.ex
@@ -171,8 +171,7 @@ defmodule Whistle.SocketHandler do
     {new_programs, responses} =
       Enum.reduce(programs, {[], []}, fn
         {id, program = %{name: ^name}}, {programs, responses} ->
-          new_vdom = Program.Connection.view(program)
-          {new_program, diff} = Program.Connection.put_new_vdom(program, new_vdom)
+          {new_program, diff} = Program.Connection.update_view(program, new_vdom)
 
           new_responses =
             if length(diff) > 0 do

--- a/lib/whistle/socket_handler.ex
+++ b/lib/whistle/socket_handler.ex
@@ -7,6 +7,16 @@ defmodule Whistle.SocketHandler do
 
   @json_library Whistle.Config.json_library()
 
+  defmodule State do
+    @type t :: %__MODULE__{
+      router: module(),
+      socket: Whistle.Socket.t(),
+      conns: [Whistle.Program.Connection.t()]
+    }
+
+    defstruct [:socket, :router, :conns]
+  end
+
   def init(req, {router, []}) do
     conn = Plug.Cowboy.Conn.conn(req)
     {:cowboy_websocket, req, {conn, router}}
@@ -14,10 +24,10 @@ defmodule Whistle.SocketHandler do
 
   def websocket_init({conn, router}) do
     {:ok,
-     %{
+     %State{
        socket: Socket.new(conn),
        router: router,
-       programs: %{}
+       conns: %{}
      }}
   end
 
@@ -27,96 +37,129 @@ defmodule Whistle.SocketHandler do
     |> Base.encode32(case: :lower, padding: false)
   end
 
-  def websocket_handle(
-        {:text, payload},
-        state = %{router: router, socket: socket, programs: programs}
-      ) do
-    payload
-    |> @json_library.decode()
-    |> case do
-      {:ok, %{"type" => "event", "program" => program_name, "handler" => handler, "args" => args}} ->
-        message = {:update, program_name, handler, args}
+  defp program_connection(conns, id) do
+    case Map.fetch(conns, id) do
+      res = {:ok, _} ->
+        res
 
-        websocket_info(message, state)
-
-      {:ok, %{"type" => "route", "program" => program_id, "uri" => uri}} ->
-        program = Map.get(programs, program_id)
-
-        case Program.Connection.route(program, uri) do
-          {:ok, new_program} ->
-            {:ok, %{state | programs: Map.put(programs, program_id, new_program)}}
-
-          {:error, _error} ->
-            {:ok, state}
-        end
-
-      {:ok, %{"type" => "leave", "program" => program_id}} ->
-        program = Map.get(programs, program_id)
-
-        Program.Registry.unsubscribe(router, program.name, self())
-        Program.Connection.notify_disconnection(program, socket)
-
-        {:ok, %{state | programs: Map.delete(programs, program_id)}}
-
-      {:ok,
-       %{
-         "type" => "join",
-         "requestId" => request_id,
-         "program" => program_name,
-         "params" => params,
-         "dom" => dom,
-         "uri" => uri
-       }} ->
-        channel_path = String.split(program_name, ":")
-
-        with {:ok, program, program_params} <- router.__match(channel_path),
-             {:ok, _pid} <-
-               Program.Registry.ensure_started(router, program_name, program, program_params),
-             {:ok, new_socket, session} <-
-               Program.Instance.authorize(
-                 router,
-                 program_name,
-                 socket,
-                 Map.merge(program_params, params)
-               ),
-             :ok <- Program.Registry.subscribe(router, program_name, self()) do
-          program_connection = Program.Connection.new(router, program_name, dom, session)
-
-          program_id = generate_connection_id()
-
-          response =
-            @json_library.encode!(%{
-              type: "joined",
-              requestId: request_id,
-              programId: program_id
-            })
-
-          Program.Connection.notify_connection(program_connection, socket)
-
-          new_program =
-            case Program.Connection.route(program_connection, uri) do
-              {:ok, new_program} ->
-                new_program
-
-              {:error, _error} ->
-                program_connection
-            end
-
-          send(self(), {:updated, program_name})
-
-          {:reply, {:text, response},
-           %{
-             state
-             | socket: new_socket,
-               programs: Map.put(programs, program_id, new_program)
-           }}
-        end
+      :error ->
+        {:error, :conn_not_found}
     end
   end
 
-  def terminate(_reason, _req, %{socket: socket, programs: programs}) do
-    Enum.each(programs, fn {_, program} ->
-      Program.Connection.notify_disconnection(program, socket)
+  def handle_conn_event("event", conn, %{"conn" => id, "handler" => handler, "args" => args}) do
+    case Program.Connection.handle_event(conn, {handler, args}) do
+      {:ok, new_conn, replies} ->
+        if length(replies) > 0 do
+          response =
+            replies
+            |> Enum.map(fn reply ->
+              %{type: "msg", program: id, payload: reply}
+            end)
+            |> @json_library.encode!()
+
+          send(self(), {:reply, {:text, response}})
+        end
+
+        {:ok, new_conn}
+
+      {:error, :program_crash} ->
+        {:error, :program_crash}
+    end
+  end
+
+  def handle_conn_event("route", conn, %{"uri" => uri}) do
+    case Program.Connection.route(conn, uri) do
+      {:ok, new_conn} ->
+        {:ok, new_conn}
+
+      error = {:error, _error} ->
+        error
+    end
+  end
+
+  def handle_event("leave", state, %{"conn" => id}) do
+    conn = Map.get(state.conns, id)
+
+    Program.Registry.unsubscribe(state.router, conn.name, self())
+    Program.Connection.notify_disconnection(conn, state.socket)
+
+    {:ok, %{state | conns: Map.delete(state.conns, id)}}
+  end
+
+  def handle_event("join", state = %{router: router, socket: socket, conns: conns}, %{
+        "ref" => request_id,
+        "program" => program_name,
+        "params" => params,
+        "dom" => dom,
+        "uri" => uri
+      }) do
+    channel_path = String.split(program_name, ":")
+
+    with {:ok, program, program_params} <- router.__match(channel_path),
+         {:ok, _pid} <-
+           Program.Registry.ensure_started(router, program_name, program, program_params),
+         {:ok, new_socket, session} <-
+           Program.Instance.authorize(
+             router,
+             program_name,
+             socket,
+             Map.merge(program_params, params)
+           ),
+         :ok <- Program.Registry.subscribe(router, program_name, self()) do
+      conn = Program.Connection.new(router, program_name, dom, session)
+
+      conn_id = generate_connection_id()
+
+      response =
+        %{
+          type: "joined",
+          ref: request_id,
+          conn: conn_id
+        }
+
+      Program.Connection.notify_connection(conn, socket)
+
+      new_conn =
+        case Program.Connection.route(conn, uri) do
+          {:ok, new_conn} ->
+            new_conn
+
+          {:error, _error} ->
+            conn
+        end
+
+      reply(response)
+      send(self(), {:updated, program_name})
+
+      {:ok,
+       %{
+         state
+         | socket: new_socket,
+           conns: Map.put(conns, conn_id, new_conn)
+       }}
+    end
+  end
+
+  def handle_event(type, state, payload = %{"conn" => id}) do
+    with {:ok, conn} <- program_connection(state.conns, id),
+         {:ok, new_conn} <- handle_conn_event(type, conn, payload) do
+      {:ok, %{state | conns: Map.put(state.conns, id, new_conn)}}
+    end
+  end
+
+  def websocket_handle({:text, payload}, state) do
+    payload
+    |> @json_library.decode()
+    |> case do
+      {:ok, payload = %{"type" => type}} ->
+        handle_event(type, state, payload)
+    end
+  end
+
+  def terminate(_reason, _req, %{socket: socket, conns: conns}) do
+    Enum.each(conns, fn {_, conn} ->
+      Program.Connection.notify_disconnection(conn, socket)
     end)
 
     :ok
@@ -129,55 +172,38 @@ defmodule Whistle.SocketHandler do
 
   def websocket_info(
         {:program_started, program_name},
-        state = %{socket: socket, programs: programs}
+        state = %{socket: socket, conns: conns}
       ) do
-    Enum.each(programs, fn program = %{name: ^program_name} ->
-      Program.Connection.notify_connection(program, socket)
+    Enum.each(conns, fn conn = %{name: ^program_name} ->
+      Program.Connection.notify_connection(conn, socket)
     end)
 
     reply_program_view(state, program_name)
   end
 
-  def websocket_info({:update, program_name, handler, args}, state = %{programs: programs}) do
-    program = Map.get(programs, program_name)
-
-    case Program.Connection.update(program, {handler, args}) do
-      {:ok, new_program, replies} ->
-        new_state = %{state | programs: Map.put(programs, program_name, new_program)}
-
-        if length(replies) > 0 do
-          response =
-            replies
-            |> Enum.map(fn reply ->
-              %{type: "msg", program: program_name, payload: reply}
-            end)
-            |> @json_library.encode!()
-
-          {:reply, {:text, response}, new_state}
-        else
-          {:ok, new_state}
-        end
-
-      {:error, :program_crash} ->
-        {:ok, state}
-    end
+  def websocket_info({:reply, response}, state) do
+    {:reply, response, state}
   end
 
   def websocket_info({:updated, name}, state) do
     reply_program_view(state, name)
   end
 
-  defp reply_program_view(state = %{programs: programs}, name) do
-    {new_programs, responses} =
-      Enum.reduce(programs, {[], []}, fn
-        {id, program = %{name: ^name}}, {programs, responses} ->
+  defp reply(message) do
+    send(self(), {:reply, {:text, @json_library.encode!(message)}})
+  end
+
+  defp reply_program_view(state = %{conns: conns}, name) do
+    {new_conns, responses} =
+      Enum.reduce(conns, {[], []}, fn
+        {id, program = %{name: ^name}}, {conns, responses} ->
           {new_program, diff} = Program.Connection.update_view(program)
 
           new_responses =
             if length(diff) > 0 do
               response = %{
                 type: "render",
-                program: id,
+                conn: id,
                 dom_patches: diff
               }
 
@@ -186,13 +212,13 @@ defmodule Whistle.SocketHandler do
               responses
             end
 
-          {programs ++ [{id, new_program}], new_responses}
+          {conns ++ [{id, new_program}], new_responses}
 
-        program, {programs, responses} ->
-          {programs ++ [program], responses}
+        program, {conns, responses} ->
+          {conns ++ [program], responses}
       end)
 
-    new_state = %{state | programs: Enum.into(new_programs, %{})}
+    new_state = %{state | conns: Enum.into(new_conns, %{})}
 
     if length(responses) > 0 do
       {:reply, {:text, @json_library.encode!(responses)}, new_state}

--- a/lib/whistle/socket_handler.ex
+++ b/lib/whistle/socket_handler.ex
@@ -171,7 +171,7 @@ defmodule Whistle.SocketHandler do
     {new_programs, responses} =
       Enum.reduce(programs, {[], []}, fn
         {id, program = %{name: ^name}}, {programs, responses} ->
-          {new_program, diff} = Program.Connection.update_view(program, new_vdom)
+          {new_program, diff} = Program.Connection.update_view(program)
 
           new_responses =
             if length(diff) > 0 do

--- a/priv/whistle.js
+++ b/priv/whistle.js
@@ -10,8 +10,8 @@
     return returnSockets;
   }
 
-  exports.log = console.log;
-  // exports.log = function() {};
+  // exports.log = console.log;
+  exports.log = function() {};
 
   exports.open = function(url) {
     if(sockets[url]) {

--- a/priv/whistle.js
+++ b/priv/whistle.js
@@ -10,8 +10,8 @@
     return returnSockets;
   }
 
-  // exports.log = console.log;
-  exports.log = function() {};
+  exports.log = console.log;
+  // exports.log = function() {};
 
   exports.open = function(url) {
     if(sockets[url]) {
@@ -100,7 +100,7 @@
       if(event == "join") {
       } else if(event == "message") {
         newFun = this.socket.on("message", function(data) {
-          if(data.program == self.id) {
+          if(data.conn == self.id) {
             fun.call(self, data);
           }
         });
@@ -114,7 +114,7 @@
       this.state = 3;
       if(this.id) {
         exports.log("leaving", this.name, this.id);
-        this.socket.send({type: "leave", program: this.id});
+        this.socket.send({type: "leave", conn: this.id});
         // left
         this.state = 4;
       }
@@ -184,7 +184,7 @@
                   fun = function(e) {
                     self.socket.send({
                       type: "event",
-                      program: self.id,
+                      conn: self.id,
                       handler: key + "." + handler.event,
                       args: [e.state.path]
                     });
@@ -218,7 +218,7 @@
 
                     self.socket.send({
                       type: "event",
-                      program: self.id,
+                      conn: self.id,
                       handler: key + "." + handler.event,
                       args: args
                     });
@@ -304,7 +304,7 @@
 
       this.socket.send({
         type: "join",
-        requestId: requestId,
+        ref: requestId,
         program: this.name,
         params: this.params,
         dom: initialDom,
@@ -313,10 +313,10 @@
 
       var joinResponseHandler = this.socket.on("message", function (data) {
         // TODO: check join error
-        if(data.requestId == requestId) {
-          exports.log("joined", self.name, data.programId);
+        if(data.ref == requestId) {
+          exports.log("joined", self.name, data.conn);
 
-          self.id = data.programId;
+          self.id = data.conn;
           self.socket.removeListener("message", joinResponseHandler);
 
           // tried to leave and we didn't join yet, so leave immediately
@@ -421,7 +421,7 @@
     this.send = function(name, payload) {
       this.socket.send({
         type: "msg",
-        program: this.id,
+        conn: this.id,
         payload: payload
       });
     }
@@ -459,7 +459,7 @@
       e.preventDefault();
       self.socket.send({
         type: "route",
-        program: self.id,
+        conn: self.id,
         uri: e.state.uri
       });
     };
@@ -481,7 +481,7 @@
             e.preventDefault();
             self.socket.send({
               type: "route",
-              program: self.id,
+              conn: self.id,
               uri: uri
             });
             window.history.pushState({uri: uri}, "", uri);
@@ -562,7 +562,7 @@
 
     this.onMessageFor = function(program, fun) {
       var newFun = function(data) {
-        if(data.program == program) {
+        if(data.conn == program) {
           fun.call(self, data);
         }
       };

--- a/priv/whistle.js
+++ b/priv/whistle.js
@@ -604,6 +604,7 @@
       if(event == "message") {
         newFun = function(e) {
           var data = JSON.parse(e.data);
+
           if(data instanceof Array) {
             data.forEach(function(message) {
               fun.call(self, message);

--- a/test/html_test.exs
+++ b/test/html_test.exs
@@ -1,10 +1,11 @@
 defmodule HtmlTest do
   use ExUnit.Case
-  doctest Whistle
   import Whistle.Html.Parser
 
   require Whistle.Html
   alias Whistle.Html
+
+  doctest Whistle.Html
 
   test "html parser" do
     number = 5

--- a/test/program_test.exs
+++ b/test/program_test.exs
@@ -136,10 +136,9 @@ defmodule ProgramTest do
     conn = Program.Connection.new(@router, @program_name, nil, %{})
 
     {:ok, %{vdom: {0, nil}, session: :something}, []} =
-             Program.Connection.update(conn, {:set_session, :something})
+      Program.Connection.update(conn, {:set_session, :something})
 
-    {%{vdom: {0, {"div", _}}}, _} =
-             Program.Connection.update_view(conn)
+    {%{vdom: {0, {"div", _}}}, _} = Program.Connection.update_view(conn)
 
     assert {0,
             Html.div([], [
@@ -148,5 +147,4 @@ defmodule ProgramTest do
               Html.button([on: [click: {:change, -1}]], "-")
             ])} == Program.Connection.view(conn)
   end
-
 end

--- a/test/program_test.exs
+++ b/test/program_test.exs
@@ -49,6 +49,10 @@ defmodule ProgramTest do
       {:ok, state + n, session}
     end
 
+    def update({:set_session, session}, state, _) do
+      {:ok, state, session}
+    end
+
     def view(_state, _session) do
       params = %{"hello" => true}
 
@@ -73,6 +77,22 @@ defmodule ProgramTest do
 
   setup do
     [conn: conn(:get, "/")]
+  end
+
+  test "program connection" do
+    start_supervised(@router)
+
+    conn = Program.Connection.new(@router, @program_name, nil, %{})
+
+    assert {:ok, %{session: :something}} =
+             Program.Connection.update(conn, {:set_session, :something})
+
+    assert {0,
+            Html.div([], [
+              Html.button([on: [click: {:change, 1}]], "+"),
+              Html.span([], ["The current number is: ", "0"]),
+              Html.button([on: [click: {:change, -1}]], "-")
+            ])} == Program.Connection.view(conn)
   end
 
   test "programs" do


### PR DESCRIPTION
- Rename program connection variables from `program` to `conn` to make it clear they are connections
- Separate event handlers in their own functions for readability
- Introduce `reply!/1` function to reply with a message instead of using `:reply` tuples